### PR TITLE
Update reports API endpoint URLs

### DIFF
--- a/components/reports-list.tsx
+++ b/components/reports-list.tsx
@@ -178,7 +178,7 @@ export function ReportsList() {
     setLoading(true);
     try {
       const offset = (page - 1) * reportsPerPage;
-      const res = await fetch(`https://voiceiqindominuslabs.vercel.app/logs/all?limit=${reportsPerPage}&offset=${offset}`);
+      const res = await fetch(`https://voiceiq-db.indominuslabs.in/logs/all?limit=${reportsPerPage}&offset=${offset}`);
       const data = await res.json();
       setReports(data.data || []);
     } catch (err) {
@@ -193,7 +193,7 @@ export function ReportsList() {
   // }, [])
   useEffect(() => {
     setLoading(true);
-  fetch(`https://voiceiqindominuslabs.vercel.app/logs/all?limit=${limit}&offset=${offset}`)
+  fetch(`https://voiceiq-db.indominuslabs.in/logs/all?limit=${limit}&offset=${offset}`)
     .then(res => res.json())
     .then(data => {
       setReports(data.data);


### PR DESCRIPTION
Changed the fetch URLs in ReportsList to use the new domain 'voiceiq-db.indominuslabs.in' instead of the old 'voiceiqindominuslabs.vercel.app'. This ensures the component fetches data from the correct backend service.